### PR TITLE
fix: fixing issue with async dependencies

### DIFF
--- a/.changeset/tiny-teams-end.md
+++ b/.changeset/tiny-teams-end.md
@@ -1,0 +1,5 @@
+---
+'@hypersphere/dity': patch
+---
+
+fixing issue with function being called multiple times when it's dependencies are async

--- a/packages/dity/src/new-version.ts
+++ b/packages/dity/src/new-version.ts
@@ -75,7 +75,10 @@ class Inj<D extends Deps, Arr extends Array<any>, Ret> {
 			const res = this.args.map(a => d.get(a))
 			const anyPromise = res.find(f => (f as any) instanceof Promise)
 			if (anyPromise) {
-				return Promise.all(res).then(vals => savedFn(...(vals as any)))
+				v = Promise.all(res).then(vals => {
+					return savedFn(...(vals as any))
+				}) as Ret
+				return v
 			} else {
 				v = savedFn(...(res as Arr))
 				return v


### PR DESCRIPTION
There was an issue with dep resolution when dependencies were async. Now it should work fine and cache values properly.